### PR TITLE
Add missing dependencies and fix scikit-image package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ nibabel==4.0.2
 numpy==1.21.6
 pandas==1.5.2
 pyradiomics==3.0.1
-scikit_image==0.19.2
+scikit-image==0.19.2
 scikit-learn==1.0.2
 scipy==1.7.3
 SimpleITK==2.2.0
@@ -17,3 +17,4 @@ lightgbm==4.4.0
 catboost==1.0.6
 cython
 pydensecrf
+wandb==0.17.2


### PR DESCRIPTION
## Summary
- correct the scikit-image package name in requirements.txt to match the actual PyPI project
- add the missing wandb dependency required by the code

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca1f1ba1848327adc4e8e68387adfe